### PR TITLE
Add Cirrus CI config file

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,16 @@
+freebsd_instance:
+  image_family: freebsd-12-2-snap
+  cpu: 8
+  memory: 16G
+
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
+task:
+  only_if: $CIRRUS_BRANCH != 'svn_head'
+  timeout_in: 120m
+  install_script:
+    - pkg install -y docproj
+  test_script:
+    - make all
+


### PR DESCRIPTION
Enable Cirrus CI to perform a complete doc tree build test. The
official mirror on GitHub, as well as anyone who pushes the repo to
GitHub can enjoy free CI functionality for all commits and pull
requests.

Reviewed by:	lwhsu, bcr
Differential Revision:	https://reviews.freebsd.org/D27530